### PR TITLE
Passt die Positionierung des Labels der Barchart Komponente an

### DIFF
--- a/static/js/directives/bar.js
+++ b/static/js/directives/bar.js
@@ -77,7 +77,14 @@ app.directive('bar', function() {
                 canvas.select('.bar-text')
                     .transition()
                     .duration(1000)
-                    .attr('x', scope.value ? xscale(scope.value) + 10 : 0)
+                    .attr('x', function () {
+                        var value = scope.value ? xscale(scope.value) : 0;
+
+                        if (xscale(scope.max) - value > 50) {
+                            return value + 10.5;
+                        }
+                        return value - 35;
+                    })
                     .text(scope.label ? scope.label : "")
             }
         }


### PR DESCRIPTION
Fügt auch den Diagrammen auf der Detailansicht einen Abstand der Zahl hinzu.
Hierzu wurde die Logik aus der Barchart Komponente weitgehend übernommen.

![Balkendiagramm mit Abstand](https://user-images.githubusercontent.com/10660618/57572784-bb7f4880-741f-11e9-8965-f5557f296702.png)

Resolves #17