### PR TITLE
Korrigiert Ausgabe bei Transparenzgesetzen oder Bundesländern ohne IFG

### DIFF
--- a/_layouts/state.html
+++ b/_layouts/state.html
@@ -6,13 +6,32 @@ layout: default
         <div class="col-md-offset-1 col-md-10">
             <div class="row">
                 <div class="col-md-12 text-center">
+                    {% assign type_text = "Informationsfreiheitsgesetz seit" %}
+
+                    {% if page.ifg_type == 'tg' %}
+                        {% assign type_text = "Transparenzgesetz seit" %}
+                    {% endif %}
+
+                    {% if page.status == 'draft' %}
+                        {% assign type_text = "Entwurf von" %}
+                    {% endif %}
+
                     {% if page.status == 'draft' %}
                         <h1 style="color: red">{{page.name}} (Entwurf)</h1>
-                        <p><em>Entwurf von {{page.ifg}}</em></p>
                     {% else %}
                         <h1>{{page.name}}</h1>
-                        <p><em>Informationsfreiheitsgesetz seit {{page.ifg}}</em></p>
                     {% endif %}
+
+                    <p>
+                        <em>
+                            {% if page.ifg_year %}
+                                {{type_text}} {{page.ifg_year}}
+                            {% else %}
+                                Kein Informationsfreiheitsgesetz
+                            {% endif %}
+                        </em>
+                    </p>
+
                     <p class="text-center">Gesamt {{overview_points}}</p>
                     {% raw %}
                     <bar value="overview_points" max="100" color="overview_color" label="overview_label" /></div>

--- a/_states/baden-wuerttemberg.md
+++ b/_states/baden-wuerttemberg.md
@@ -1,7 +1,8 @@
 ---
 name: Baden-Württemberg
 link: baden-wuerttemberg
-ifg: 2016
+ifg_year: 2016
+ifg_type: ifg
 ifg_link: "http://www.landesrecht-bw.de/jportal/portal/t/g2u/page/bsbawueprod.psml;jsessionid=7B9F63D2264ED25A8E80DA5127A56164.jp91?pid=Dokumentanzeige&showdoccase=1&js_peid=Trefferliste&documentnumber=1&numberofresults=1&fromdoctodoc=yes&doc.id=jlr-InfFrGBWpP10&doc.part=X&doc.price=0.0#focuspoint"
 layout: state
 status: complete

--- a/_states/berlin.md
+++ b/_states/berlin.md
@@ -1,7 +1,8 @@
 ---
 name: Berlin
 link: berlin
-ifg: 1998, letzte Änderung 2016
+ifg_year: 1998, letzte Änderung 2016
+ifg_type: ifg
 ifg_link: "http://gesetze.berlin.de/jportal/?quelle=jlink&query=InfFrG+BE&psml=bsbeprod.psml&max=true&aiz=true"
 layout: state
 status: complete

--- a/_states/brandenburg.md
+++ b/_states/brandenburg.md
@@ -1,7 +1,8 @@
 ---
 name: Brandenburg
 link: brandenburg
-ifg: 1998, letzte Änderung 2013
+ifg_year: 1998, letzte Änderung 2013
+ifg_type: ifg
 ifg_link: "http://bravors.brandenburg.de/de/gesetze-212780"
 layout: state
 status: complete

--- a/_states/bremen.md
+++ b/_states/bremen.md
@@ -1,7 +1,8 @@
 ---
 name: Bremen
 link: bremen
-ifg: 2006, letzte Änderung 2015
+ifg_year: 2006, letzte Änderung 2015
+ifg_type: ifg
 ifg_link: "http://transparenz.bremen.de/sixcms/detail.php?gsid=bremen2014_tp.c.67770.de&asl=bremen203_tpgesetz.c.55340.de&template=20_gp_ifg_meta_detail_d"
 layout: state
 status: complete

--- a/_states/bund.md
+++ b/_states/bund.md
@@ -1,7 +1,8 @@
 ---
 name: Bund
 link: bund
-ifg: 2006, zuletzt geändert 2013
+ifg_year: 2006, zuletzt geändert 2013
+ifg_type: ifg
 ifg_link: "https://www.gesetze-im-internet.de/ifg/BJNR272200005.html"
 layout: state
 status: complete

--- a/_states/hamburg.md
+++ b/_states/hamburg.md
@@ -1,7 +1,8 @@
 ---
 name: Hamburg
 link: hamburg
-ifg: 2012
+ifg_year: 2012
+ifg_type: tg
 ifg_link: "http://transparenz.hamburg.de/das-hmbtg/"
 layout: state
 status: complete

--- a/_states/hessen.md
+++ b/_states/hessen.md
@@ -3,7 +3,8 @@ layout: state
 name: Hessen
 link: hessen
 status: complete
-ifg: 2018
+ifg_year: 2018
+ifg_type: ifg
 ---
 In Hessen gibt es seit 2018 ein Informationsfreiheitsgesetz.
 

--- a/_states/mecklenburg-vorpommern.md
+++ b/_states/mecklenburg-vorpommern.md
@@ -1,7 +1,8 @@
 ---
 name: Mecklenburg-Vorpommern
 link: mecklenburg-vorpommern
-ifg: 2006, letzte Änderung 2011
+ifg_year: 2006, letzte Änderung 2011
+ifg_type: ifg
 ifg_link: "http://www.landesrecht-mv.de/jportal/portal/page/bsmvprod.psml?showdoccase=1&doc.id=jlr-InfFrGMVrahmen&doc.part=X&doc.origin=bs&st=lr"
 layout: state
 status: complete

--- a/_states/nrw.md
+++ b/_states/nrw.md
@@ -1,7 +1,8 @@
 ---
 name: NRW
 link: nrw
-ifg: 2001
+ifg_year: 2001
+ifg_type: ifg
 ifg_link: "https://recht.nrw.de/lmi/owa/pl_text_anzeigen?v_id=4820020930120743668"
 layout: state
 status: complete

--- a/_states/rheinland-pfalz.md
+++ b/_states/rheinland-pfalz.md
@@ -1,7 +1,8 @@
 ---
 name: Rheinland-Pfalz
 link: rheinland-pfalz
-ifg: 2016
+ifg_year: 2016
+ifg_type: tg
 ifg_link: "http://www.landesrecht.rlp.de/jportal/portal/t/3jm/page/bsrlpprod.psml;jsessionid=89FF88C31F2B1651FD4FE86448CF26DF.jp10?pid=Dokumentanzeige&showdoccase=1&js_peid=Trefferliste&documentnumber=3&numberofresults=8&fromdoctodoc=yes&doc.id=jlr-TranspGRPrahmen&doc.part=X&doc.price=0.0#focuspoint"
 layout: state
 status: complete

--- a/_states/saarland.md
+++ b/_states/saarland.md
@@ -1,7 +1,8 @@
 ---
 name: Saarland
 link: saarland
-ifg: 2006, letzte Änderung 2015
+ifg_year: 2006, letzte Änderung 2015
+ifg_type: ifg
 ifg_link: "http://sl.juris.de/cgi-bin/landesrecht.py?d=http://sl.juris.de/sl/gesamt/SIFG_SL_2006.htm#SIFG_SL_2006_rahmen"
 layout: state
 status: complete

--- a/_states/sachsen-anhalt.md
+++ b/_states/sachsen-anhalt.md
@@ -1,7 +1,8 @@
 ---
 name: Sachsen-Anhalt
 link: sachsen-anhalt
-ifg: 2008
+ifg_year: 2008
+ifg_type: ifg
 ifg_link: "http://www.landesrecht.sachsen-anhalt.de/jportal/?quelle=jlink&query=InfZG+ST&psml=bssahprod.psml&max=true&aiz=true"
 layout: state
 status: complete

--- a/_states/schleswig-holstein.md
+++ b/_states/schleswig-holstein.md
@@ -1,7 +1,8 @@
 ---
 name: Schleswig-Holstein
 link: schleswig-holstein
-ifg: 2012, wird 2017 geändert
+ifg_year: 2012, wird 2017 geändert
+ifg_type: ifg
 ifg_link: "http://www.gesetze-rechtsprechung.sh.juris.de/jportal/portal/t/gx/page/bsshoprod.psml?pid=Dokumentanzeige&showdoccase=1&js_peid=Trefferliste&documentnumber=1&numberofresults=1&fromdoctodoc=yes&doc.id=jlr-InfoZGSHrahmen&doc.part=X&doc.price=0.0#focuspoint"
 layout: state
 status: complete

--- a/_states/thueringen.md
+++ b/_states/thueringen.md
@@ -1,7 +1,8 @@
 ---
 name: Thüringen
 link: thueringen 
-ifg: 2012
+ifg_year: 2012
+ifg_type: ifg
 ifg_link: "http://landesrecht.thueringen.de/jportal/?quelle=jlink&query=InfFrG+TH&psml=bsthueprod.psml&max=true"
 layout: state
 status: draft


### PR DESCRIPTION
Ich habe den Parameter ifg in ifg_year umbenannt, da hier eigentlich nur die Jahreszahl gespeichert wurde. Zusätzlich gibt es jetzt ein _ifg_type_ Attribut

Resolves #20